### PR TITLE
add action to publish to pypi

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,24 @@
+name: Deploy
+on: [push, pull_request]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade build twine
+      - name: Create and check sdist and wheel packages
+        run: |
+          python3 -m build
+          twine check dist/*
+      - name: Publish to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'jonas-fuchs'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
@jonas-fuchs this github action can publish your tool automatically to pypi if you tag a new release.

You need to create a pypi account and get an API token, which you need to put into you github repository preferences.
I can help you with that if you like.