### PR TITLE
sequence length check

### DIFF
--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -173,6 +173,8 @@ def shared_workflow(args, log_file):
 
     # read in alignment and preprocess
     preprocessed_alignment = alignment.preprocess(args.input[0])
+    # check alignment length distribution
+    logging.check_alignment_length(preprocessed_alignment, log_file)
 
     # estimate threshold or number of ambiguous bases if args were not supplied
     if args.threshold is None or args.n_ambig is None:


### PR DESCRIPTION
integrated a simple check of the alignment that warns the user if there are sequence lengths that are significantly  different to the alignment mean. runs at the very start of varvamp.