### PR TITLE
Bug fixes

### DIFF
--- a/varvamp/__init__.py
+++ b/varvamp/__init__.py
@@ -1,3 +1,3 @@
 """Tool to design amplicons for highly variable virusgenomes"""
 _program = "varvamp"
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -180,8 +180,11 @@ def shared_workflow(args, log_file):
     # estimate threshold or number of ambiguous bases if args were not supplied
     if args.threshold is None or args.n_ambig is None:
         args.threshold, args.n_ambig = param_estimation.get_parameters(preprocessed_alignment, args, log_file)
-    if args.mode == "qpcr" and args.n_ambig >= 1 and args.pn_ambig is None:
-        args.pn_ambig = args.n_ambig - 1
+    if args.mode == "qpcr" and args.pn_ambig is None:
+        if args.n_ambig == 0:
+            args.pn_ambig = 0
+        if args.n_ambig > 0:
+            args.pn_ambig = args.n_ambig - 1
         with open(log_file, "a") as f:
             print(f"Automatic parameter selection set -pa {args.pn_ambig}.", file=f)
 

--- a/varvamp/scripts/logging.py
+++ b/varvamp/scripts/logging.py
@@ -173,7 +173,7 @@ def raise_arg_errors(args, log_file):
     if args.mode == "qpcr":
         if args.pn_ambig < 0:
             raise_error(
-                "number of ambiguous characters in the qPCR probe cannot be 0.",
+                "number of ambiguous characters in the qPCR probe cannot negative.",
                 log_file,
                 exit=True
             )
@@ -283,6 +283,7 @@ def confirm_config(args, log_file):
             "QPRIMER_DIFF",
             "QPROBE_TEMP_DIFF",
             "QPROBE_DISTANCE",
+            "END_OVERLAP",
             "QAMPLICON_LENGTH",
             "QAMPLICON_GC",
             "QAMPLICON_DEL_CUTOFF"
@@ -379,6 +380,7 @@ def confirm_config(args, log_file):
         ("max base penalty", config.PRIMER_MAX_BASE_PENALTY),
         ("primer permutation penalty", config.PRIMER_PERMUTATION_PENALTY),
         ("qpcr flanking primer difference", config.QPRIMER_DIFF),
+        ("probe and primer end overlap", config.END_OVERLAP),
         ("qpcr deletion size still considered for deltaG calculation", config.QAMPLICON_DEL_CUTOFF),
         ("maximum difference between primer and blast db", config.BLAST_MAX_DIFF),
         ("multiplier of the maximum length for non-specific amplicons", config.BLAST_SIZE_MULTI),

--- a/varvamp/scripts/logging.py
+++ b/varvamp/scripts/logging.py
@@ -173,7 +173,7 @@ def raise_arg_errors(args, log_file):
     if args.mode == "qpcr":
         if args.pn_ambig < 0:
             raise_error(
-                "number of ambiguous characters in the qPCR probe cannot negative.",
+                "number of ambiguous characters in the qPCR probe cannot be negative.",
                 log_file,
                 exit=True
             )


### PR DESCRIPTION
- fixed crashing if `-a` = 0 in qpcr mode with `-pa` not set
- added logging for end overlap