### PR TITLE
Fixes to BLAST functionality and refactoring

### DIFF
--- a/varvamp/__init__.py
+++ b/varvamp/__init__.py
@@ -1,3 +1,3 @@
 """Tool to design amplicons for highly variable virusgenomes"""
 _program = "varvamp"
-__version__ = "1.1.3"
+__version__ = "1.2.0"

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -335,7 +335,7 @@ def single_workflow(args, amplicons, all_primers, log_file):
     workflow part specific for single mode
     """
 
-    amplicon_scheme = scheme.find_single_amplicons(amplicons, all_primers, args.report_n)
+    amplicon_scheme = scheme.find_single_amplicons(amplicons, args.report_n)
     logging.varvamp_progress(
         log_file,
         progress=0.9,

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -374,6 +374,7 @@ def tiled_workflow(args, amplicons, left_primer_candidates, right_primer_candida
         reporting.write_dimers(results_dir, dimers_not_solved)
 
     # evaluate coverage
+    # ATTENTION: Genome coverage of the scheme might still change slightly through resolution of primer dimers, but this potential, minor inaccuracy is currently accepted.
     percent_coverage = round(coverage/len(ambiguous_consensus)*100, 2)
     logging.varvamp_progress(
         log_file,

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -502,6 +502,18 @@ def main(sysargs=sys.argv[1:]):
     reporting.write_fasta(data_dir, "majority_consensus", majority_consensus)
     reporting.write_fasta(results_dir, "ambiguous_consensus", ambiguous_consensus)
 
+    # Functions called from here on return lists of amplicons that are refined step-wise into final schemes.
+    # These lists that are passed between functions and later used for reporting consist of dictionary elemnts,
+    # which represent individual amplicons. A minimal amplicon dict could take the form:
+    # {
+    #     "id": amplicon_name,
+    #     "penalty": amplicon_cost,
+    #     "length": amplicon_length,
+    #     "LEFT": [left primer data],
+    #     "RIGHT": [right primer data]
+    # }
+    # to which different functions may add additional information.
+
     # SINGLE/TILED mode
     if args.mode == "tiled" or args.mode == "single":
         all_primers, amplicons, off_target_amplicons = single_and_tiled_shared_workflow(

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -549,7 +549,7 @@ def main(sysargs=sys.argv[1:]):
             amplicon_scheme.sort(key=lambda x: x["LEFT"][1])
         else:
             # make sure amplicons with no off-target products and with low penalties get the lowest numbers
-            amplicon_scheme.sort(key=lambda x: (x["off_targets"], x["penalty"]))
+            amplicon_scheme.sort(key=lambda x: (x.get("off_targets", False), x["penalty"]))
         reporting.write_all_primers(data_dir, all_primers)
         reporting.write_scheme_to_files(
             results_dir,

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -314,9 +314,9 @@ def single_and_tiled_shared_workflow(args, left_primer_candidates, right_primer_
 
     if args.database is not None:
         # create blast query
-        query_path = blast.create_BLAST_query(all_primers, amplicons, data_dir)
+        query_path = blast.create_BLAST_query(amplicons, data_dir)
         # perform primer blast
-        amplicons, off_target_amplicons = blast.primer_blast(
+        amplicons = blast.primer_blast(
             data_dir,
             args.database,
             query_path,
@@ -326,10 +326,8 @@ def single_and_tiled_shared_workflow(args, left_primer_candidates, right_primer_
             log_file,
             mode="single_tiled"
         )
-    else:
-        off_target_amplicons = []
 
-    return all_primers, amplicons, off_target_amplicons
+    return all_primers, amplicons
 
 
 def single_workflow(args, amplicons, all_primers, log_file):
@@ -449,9 +447,9 @@ def qpcr_workflow(args, data_dir, alignment_cleaned, ambiguous_consensus, majori
     # run blast if db is given
     if args.database is not None:
         # create blast query
-        query_path = blast.create_BLAST_query_qpcr(qpcr_scheme_candidates, data_dir)
+        query_path = blast.create_BLAST_query(qpcr_scheme_candidates, data_dir, mode="qpcr")
         # perform primer blast
-        qpcr_scheme_candidates, off_target_amplicons = blast.primer_blast(
+        qpcr_scheme_candidates = blast.primer_blast(
             data_dir,
             args.database,
             query_path,
@@ -516,7 +514,7 @@ def main(sysargs=sys.argv[1:]):
 
     # SINGLE/TILED mode
     if args.mode == "tiled" or args.mode == "single":
-        all_primers, amplicons, off_target_amplicons = single_and_tiled_shared_workflow(
+        all_primers, amplicons = single_and_tiled_shared_workflow(
             args,
             left_primer_candidates,
             right_primer_candidates,

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -583,7 +583,7 @@ def main(sysargs=sys.argv[1:]):
         # write files
 
         # make sure amplicons with no off-target products and with low penalties get the lowest numbers
-        final_schemes.sort(key=lambda x: (x["off_targets"], x["penalty"]))
+        final_schemes.sort(key=lambda x: (x.get("off_targets", False), x["penalty"]))
         reporting.write_regions_to_bed(probe_regions, data_dir, "probe")
         reporting.write_qpcr_to_files(results_dir, final_schemes, ambiguous_consensus, log_file)
         reporting.varvamp_plot(

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -529,8 +529,15 @@ def main(sysargs=sys.argv[1:]):
                 log_file,
                 results_dir
             )
+
         # write files
-        amplicon_scheme.sort(key=lambda x: x["LEFT"][1])
+
+        if args.mode == "tiled":
+            # assign amplicon numbers from 5' to 3' along the genome
+            amplicon_scheme.sort(key=lambda x: x["LEFT"][1])
+        else:
+            # make sure amplicons with no off-target products and with low penalties get the lowest numbers
+            amplicon_scheme.sort(key=lambda x: (x["off_targets"], x["penalty"]))
         reporting.write_all_primers(data_dir, all_primers)
         reporting.write_scheme_to_files(
             results_dir,
@@ -560,8 +567,11 @@ def main(sysargs=sys.argv[1:]):
             right_primer_candidates,
             log_file
         )
+
         # write files
-        final_schemes.sort(key=lambda x: x["LEFT"][1])
+
+        # make sure amplicons with no off-target products and with low penalties get the lowest numbers
+        final_schemes.sort(key=lambda x: (x["off_targets"], x["penalty"]))
         reporting.write_regions_to_bed(probe_regions, data_dir, "probe")
         reporting.write_qpcr_to_files(results_dir, final_schemes, ambiguous_consensus, log_file)
         reporting.varvamp_plot(

--- a/varvamp/scripts/default_config.py
+++ b/varvamp/scripts/default_config.py
@@ -4,7 +4,7 @@ This contains all varVAMP parameters.
 
 # List of all known parameters. DO NOT CHANGE!
 __all__ = [
-    'BLAST_MAX_DIFF', 'BLAST_PENALTY', 'BLAST_SETTINGS', 'BLAST_SIZE_MULTI',
+    'BLAST_MAX_DIFF', 'BLAST_SETTINGS', 'BLAST_SIZE_MULTI',
     'END_OVERLAP',
     'PCR_DNA_CONC', 'PCR_DNTP_CONC', 'PCR_DV_CONC', 'PCR_MV_CONC',
     'PRIMER_3_PENALTY', 'PRIMER_GC_END', 'PRIMER_GC_PENALTY',
@@ -74,7 +74,6 @@ BLAST_SETTINGS = {  # blast settings for query search
 }
 BLAST_MAX_DIFF = 0.5  # min percent match between primer and BLAST hit (coverage and/or mismatches)
 BLAST_SIZE_MULTI = 2  # multiplier for the max_amp size of off targets (in relation to max amp size)
-BLAST_PENALTY = 50  # amplicon penalty increase -> considered only if no other possibilities
 
 # nucleotide definitions, do NOT change
 NUCS = set("atcg")

--- a/varvamp/scripts/logging.py
+++ b/varvamp/scripts/logging.py
@@ -291,7 +291,6 @@ def confirm_config(args, log_file):
         (
             "BLAST_MAX_DIFF",
             "BLAST_SIZE_MULTI",
-            "BLAST_PENALTY"
         )
     ]
 
@@ -384,7 +383,6 @@ def confirm_config(args, log_file):
         ("qpcr deletion size still considered for deltaG calculation", config.QAMPLICON_DEL_CUTOFF),
         ("maximum difference between primer and blast db", config.BLAST_MAX_DIFF),
         ("multiplier of the maximum length for non-specific amplicons", config.BLAST_SIZE_MULTI),
-        ("blast penalty for off targets", config.BLAST_PENALTY)
     ]
     for var_type, var in non_negative_var:
         if var < 0:
@@ -467,11 +465,6 @@ def confirm_config(args, log_file):
             "off-targets should be considered at least in the range of the maximal amplicon length.",
             log_file,
             exit=True
-        )
-    if config.BLAST_PENALTY < 10:
-        raise_error(
-            "giving a too small penalty could result in the selection of off-target producing amplicons in the final scheme.",
-            log_file,
         )
     # confirm proper BLAST settings in dictionary
     if not isinstance(config.BLAST_SETTINGS, dict):

--- a/varvamp/scripts/primers.py
+++ b/varvamp/scripts/primers.py
@@ -386,13 +386,13 @@ def find_best_primers(left_primer_candidates, right_primer_candidates):
         primer_candidates.sort(key=lambda x: (x[3], x[1]))
         # ini everything with the primer with the lowest penalty
         to_retain = [primer_candidates[0]]
-        primer_ranges = list(range(primer_candidates[0][1], primer_candidates[0][2]+1))
+        primer_ranges = list(range(primer_candidates[0][1], primer_candidates[0][2]))
         primer_set = set(primer_ranges)
 
         for primer in primer_candidates:
             # get the thirds of the primer, only consider the middle
             thirds_len = int((primer[2] - primer[1])/3)
-            primer_positions = list(range(primer[1] + thirds_len, primer[2] - thirds_len + 1))
+            primer_positions = list(range(primer[1] + thirds_len, primer[2] - thirds_len))
             # check if none of the nucleotides of the next primer
             # are already covered by a better primer
             if not any(x in primer_positions for x in primer_set):

--- a/varvamp/scripts/reporting.py
+++ b/varvamp/scripts/reporting.py
@@ -350,12 +350,12 @@ def write_dimers(path, primer_dimers):
             "pool\tprimer_name_1\tprimer_name_2\tdimer melting temp",
             file=tsv
         )
-        for dimers in primer_dimers:
+        for pool, primer1, primer2 in primer_dimers:
             print(
-                dimers[0][0],
-                dimers[0][2],
-                dimers[1][2],
-                round(primers.calc_dimer(dimers[0][3][0], dimers[1][3][0]).tm, 1),
+                pool,
+                primer1[1],
+                primer2[1],
+                round(primers.calc_dimer(primer1[2][0], primer2[2][0]).tm, 1),
                 sep="\t",
                 file=tsv
             )

--- a/varvamp/scripts/reporting.py
+++ b/varvamp/scripts/reporting.py
@@ -149,7 +149,7 @@ def write_qpcr_to_files(path, final_schemes, ambiguous_consensus, log_file):
                 amp["RIGHT"][2],
                 amp_name,
                 round(amp["penalty"], 1),
-                "+",
+                ".",
                 sep="\t",
                 file=bed
             )
@@ -313,7 +313,7 @@ def write_scheme_to_files(path, amplicon_scheme, ambiguous_consensus, mode, log_
             print(
                 "ambiguous_consensus",
                 *record,
-                "+",
+                ".",
                 sep="\t",
                 file=bed
             )

--- a/varvamp/scripts/reporting.py
+++ b/varvamp/scripts/reporting.py
@@ -177,9 +177,7 @@ def write_qpcr_to_files(path, final_schemes, ambiguous_consensus, log_file):
                 file=tsv
             )
             # write tsv2
-            for oligo_type in ["PROBE", "LEFT", "RIGHT"]:
-                if oligo_type == "penalty" or oligo_type == "deltaG":
-                    continue
+            for oligo_type in ["LEFT", "PROBE", "RIGHT"]:
                 seq = ambiguous_consensus[amp[oligo_type][1]:amp[oligo_type][2]]
                 if oligo_type == "RIGHT" or (oligo_type == "PROBE" and amp["PROBE"][5] == "-"):
                     seq = primers.rev_complement(seq)

--- a/varvamp/scripts/reporting.py
+++ b/varvamp/scripts/reporting.py
@@ -149,6 +149,7 @@ def write_qpcr_to_files(path, final_schemes, ambiguous_consensus, log_file):
                 amp["RIGHT"][2],
                 amp_name,
                 round(amp["penalty"], 1),
+                "+",
                 sep="\t",
                 file=bed
             )
@@ -312,6 +313,7 @@ def write_scheme_to_files(path, amplicon_scheme, ambiguous_consensus, mode, log_
             print(
                 "ambiguous_consensus",
                 *record,
+                "+",
                 sep="\t",
                 file=bed
             )

--- a/varvamp/scripts/scheme.py
+++ b/varvamp/scripts/scheme.py
@@ -21,12 +21,12 @@ def construct_graph(nodes, init_graph):
         graph[node] = {}
 
     graph.update(init_graph)
-
+    print(graph)
+    return graph
     for node, neighbors in graph.items():
         for neighbor in neighbors.keys():
             if graph[neighbor].get(node, False) is False:
                 graph[neighbor][node] = (float("infinity"), 0)
-
     return graph
 
 
@@ -277,7 +277,6 @@ def find_best_covering_scheme(amplicons, amplicon_graph):
         # if no previous nodes are found but the single amplicon results in the largest
         # coverage - return as the best scheme
         amplicon_path = [best_start_node]
-
     return best_coverage, create_scheme_dic(amplicon_path, amps_by_id)
 
 
@@ -394,7 +393,7 @@ def find_single_amplicons(amplicons, all_primers, n):
     from all found amplicons. only for the SINGLE mode.
     """
     # sort amplicons
-    sorted_amplicons = sorted(amplicons, key=lambda x: (x.get("offset_targets"), x["penalty"]))
+    sorted_amplicons = sorted(amplicons, key=lambda x: (x.get("off_targets", False), x["penalty"]))
     to_retain = []
     retained_ranges = []
     # find lowest non-overlapping

--- a/varvamp/scripts/scheme.py
+++ b/varvamp/scripts/scheme.py
@@ -21,8 +21,6 @@ def construct_graph(nodes, init_graph):
         graph[node] = {}
 
     graph.update(init_graph)
-    print(graph)
-    return graph
     for node, neighbors in graph.items():
         for neighbor in neighbors.keys():
             if graph[neighbor].get(node, False) is False:

--- a/varvamp/scripts/scheme.py
+++ b/varvamp/scripts/scheme.py
@@ -319,7 +319,7 @@ def get_overlapping_primers(dimer, left_primer_candidates, right_primer_candidat
         overlapping_primers_temp = []
         thirds_len = int((primer[3][2] - primer[3][1]) / 3)
         # get the middle third of the primer (here are the previously excluded primers)
-        overlap_set = set(range(primer[3][1] + thirds_len, primer[3][2] - thirds_len + 1))
+        overlap_set = set(range(primer[3][1] + thirds_len, primer[3][2] - thirds_len))
         # check in which list to look for them
         if "RIGHT" in primer[2]:
             primers_to_test = right_primer_candidates
@@ -327,7 +327,7 @@ def get_overlapping_primers(dimer, left_primer_candidates, right_primer_candidat
             primers_to_test = left_primer_candidates
         # and check this list for all primers that overlap
         for potential_new in primers_to_test:
-            primer_positions = list(range(potential_new[1], potential_new[2]+1))
+            primer_positions = list(range(potential_new[1], potential_new[2]))
             if not any(x in primer_positions for x in overlap_set):
                 continue
             overlapping_primers_temp.append((primer[0], primer[1], primer[2], potential_new))
@@ -399,15 +399,13 @@ def find_single_amplicons(amplicons, all_primers, n):
     # find lowest non-overlapping
     for amp in sorted_amplicons:
         overlaps_retained = False
-        amp_range = range(amp["LEFT"][1], amp["RIGHT"][2]+1)
+        amp_range = range(amp["LEFT"][1], amp["RIGHT"][2])
         for r in retained_ranges:
-            if amp_range.start in r or amp_range.stop in r or r.start in amp_range or r.stop in amp_range:
+            if amp_range.start < r.stop and r.start < amp_range.stop:
                 overlaps_retained = True
                 break
         if not overlaps_retained:
-            retained_ranges.append(
-                range(amp["LEFT"][1], amp["RIGHT"][2]+1)
-            )
+            retained_ranges.append(amp_range)
             to_retain.append(amp)
             if len(to_retain) == n:
                 break

--- a/varvamp/scripts/scheme.py
+++ b/varvamp/scripts/scheme.py
@@ -394,7 +394,7 @@ def check_and_solve_heterodimers(amplicon_scheme, left_primer_candidates, right_
     return primer_dimers
 
 
-def find_single_amplicons(amplicons, all_primers, n):
+def find_single_amplicons(amplicons, n):
     """
     find non-overlapping amplicons with low penalties
     from all found amplicons. only for the SINGLE mode.


### PR DESCRIPTION
CHANGELOG

Changes around BLAST functionality:
- Off-target amplicons are now reported as intended in the logs
- Off-target amplicons are now *always* considered last for the final
  scheme (no penalty is used, but the fact that they had BLAST matches
gets recorded)
- The BLAST_PENALTY config option is no longer needed and has been removed
- Added a new off_target_amplicons column to the qPCR design, the qPCR primer and the (single/tiled) primer tsv outputs to indicate which final amplicons had BLAST hits

General reporting changes:
- Amplicon numbering now proceeds from 5' to 3' even across pools for the tiled mode and from lowest penalty to highest for the other modes (previously additional BLAST penalties weren't considered during penalty-sorting.
- In the primer bed file output in tiled mode, primers are now ordered according to the amplicon number without taking the pool into account
- In the primer bed file output in qPCR mode, oligos from the same set are now ordered LEFT, PROBE, RIGHT, i.e. by position on the reference
- The per-base mismatch plot now uses final primer names as panel titles
- The amplicon bed file, in all modes, is now formatted as proper six-column bed

Algorithmic fixes and enhancements:
- The internal representation of amplicon schemes has been unified/simplified across the different modes and steps of the analysis
- Search for final non-overlapping amplicons in single mode and for non-overlapping amplicons passing deltaG in qpcr mode has been optimized and is now significantly faster
- Some off-by-one errors in internal primer and amplicon interval calculations have been fixed
