### PR TITLE
enforced overlap between amplicon inserts in tiled mode

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,7 +62,7 @@ optional arguments:
   --name varVAMP                name of the scheme
   -ol 1000, --opt-length 1000	optimal length of the amplicons
   -ml 1500, --max-length 1500	max length of the amplicons
-  -o 100, --overlap 100		min overlap of the amplicons
+  -o 100, --overlap 100		min overlap of the amplicon inserts
 ```
 **qpcr** mode:
 ```shell

--- a/varvamp/__init__.py
+++ b/varvamp/__init__.py
@@ -1,3 +1,3 @@
 """Tool to design amplicons for highly variable virusgenomes"""
 _program = "varvamp"
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -119,7 +119,7 @@ def get_args(sysargs):
         type=int,
         metavar="100",
         default=100,
-        help="min overlap of the amplicons"
+        help="min overlap of the amplicon inserts"
     )
     SINGLE_parser.add_argument(
         "-n",

--- a/varvamp/command.py
+++ b/varvamp/command.py
@@ -505,8 +505,8 @@ def main():
     # write files that are shared in all modes
     reporting.write_regions_to_bed(primer_regions, args.name, data_dir)
     reporting.write_alignment(data_dir, alignment_cleaned)
-    reporting.write_fasta(data_dir, f"majority_consensus", f"{args.name}_consensus",majority_consensus)
-    reporting.write_fasta(results_dir, f"ambiguous_consensus", f"{args.name}_consensus", ambiguous_consensus)
+    reporting.write_fasta(data_dir, f"majority_consensus", f"{args.name}_majority_consensus",majority_consensus)
+    reporting.write_fasta(results_dir, f"ambiguous_consensus", f"{args.name}_ambiguous_consensus", ambiguous_consensus)
 
     # Functions called from here on return lists of amplicons that are refined step-wise into final schemes.
     # These lists that are passed between functions and later used for reporting consist of dictionary elemnts,

--- a/varvamp/scripts/logging.py
+++ b/varvamp/scripts/logging.py
@@ -147,7 +147,7 @@ def raise_arg_errors(args, log_file):
                 log_file,
                 exit=True
             )
-        if args.overlap < 50:
+        if args.overlap < 10:
             raise_error(
                 "small overlaps might hinder downstream analyses. Consider increasing.",
                 log_file

--- a/varvamp/scripts/reporting.py
+++ b/varvamp/scripts/reporting.py
@@ -53,7 +53,7 @@ def write_regions_to_bed(primer_regions, scheme_name, path, mode=None):
     with open(outfile, 'w') as o:
         for counter, region in enumerate(primer_regions):
             print(
-                f"{scheme_name}_consensus",
+                f"{scheme_name}_ambiguous_consensus",
                 region[0],
                 region[1],
                 "REGION_"+str(counter),
@@ -70,7 +70,7 @@ def write_primers_to_bed(outfile, scheme_name, primer_name, primer_properties, n
         # write header for primer bed
         if os.path.getsize(outfile) == 0 and sequence is not None:
             print("#chrom\tchromStart\tchromEnd\tprimer-name\tpool\tstrand\tprimer-sequence", file=o)
-        data = [f"{scheme_name}_consensus",
+        data = [f"{scheme_name}_ambiguous_consensus",
             primer_properties[1],  # start
             primer_properties[2],  # stop
             primer_name,
@@ -150,7 +150,7 @@ def write_qpcr_to_files(path, final_schemes, ambiguous_consensus, scheme_name, l
             amp_name = f"{scheme_name}_{n}"
             # write bed amplicon file
             print(
-                f"{scheme_name}_consensus",
+                f"{scheme_name}_ambiguous_consensus",
                 amp["LEFT"][1],
                 amp["RIGHT"][2],
                 amp_name,
@@ -329,7 +329,7 @@ def write_scheme_to_files(path, amplicon_scheme, ambiguous_consensus, scheme_nam
         # write amplicon bed with amplicons sorted by start position
         for record in sorted(amplicon_bed_records, key=lambda x: x[0]):
             print(
-                f"{scheme_name}_consensus",
+                f"{scheme_name}_ambiguous_consensus",
                 *record,
                 ".",
                 sep="\t",

--- a/varvamp/scripts/reporting.py
+++ b/varvamp/scripts/reporting.py
@@ -68,8 +68,6 @@ def write_primers_to_bed(outfile, scheme_name, primer_name, primer_properties, n
     """
     with open(outfile, 'a') as o:
         # write header for primer bed
-        if os.path.getsize(outfile) == 0 and sequence is not None:
-            print("#chrom\tchromStart\tchromEnd\tprimer-name\tpool\tstrand\tprimer-sequence", file=o)
         data = [f"{scheme_name}_ambiguous_consensus",
             primer_properties[1],  # start
             primer_properties[2],  # stop

--- a/varvamp/scripts/scheme.py
+++ b/varvamp/scripts/scheme.py
@@ -102,14 +102,14 @@ def create_amplicon_graph(amplicons, min_overlap):
 
     # add the maximum len of a primer to ensure that possible amplicon starts
     # before the min overlap
-    min_overlap = min_overlap + config.PRIMER_SIZES[2]
+    min_overlap = min_overlap + config.PRIMER_SIZES[1]
 
     for current_amplicon in amplicons:
         # remember all vertices
         amplicon_id = current_amplicon["id"]
         nodes.append(amplicon_id)
         start = current_amplicon["LEFT"][1] + current_amplicon["length"]/2
-        stop = current_amplicon["RIGHT"][2] - min_overlap
+        stop = current_amplicon["RIGHT"][1] - min_overlap
         for next_amplicon in amplicons:
             # check if the next amplicon lies within the start/stop range of
             # the current amplicon and if its non-overlapping part is large


### PR DESCRIPTION
- enforce insert overlap in tiled mode. Previously amplicon overlaps were scored which could lead to overlapping of fw and rv primers of flanking amplicons. Now varVAMP considers overlaps between two primers of flanking amplicons to guarantee sequence overlaps even after primer trimming.
- changed the consensus file names as this caused issues with galaxy tests in the previous version.
- deleted header from primer bed files to ensure compatibility with other tools